### PR TITLE
PHP 8.0 compatibility: remove spacing within namespaced names

### DIFF
--- a/lib/Peast/Syntax/Node/JSX/JSXElement.php
+++ b/lib/Peast/Syntax/Node/JSX/JSXElement.php
@@ -9,8 +9,8 @@
  */
 namespace Peast\Syntax\Node\JSX;
 
-use \Peast\Syntax\Node\Node;
-use \Peast \Syntax\Node\Expression;
+use Peast\Syntax\Node\Node;
+use Peast\Syntax\Node\Expression;
 
 /**
  * A node that represents a JSX element.

--- a/lib/Peast/Syntax/Node/JSX/JSXFragment.php
+++ b/lib/Peast/Syntax/Node/JSX/JSXFragment.php
@@ -9,8 +9,8 @@
  */
 namespace Peast\Syntax\Node\JSX;
 
-use \Peast\Syntax\Node\Node;
-use \Peast \Syntax\Node\Expression;
+use Peast\Syntax\Node\Node;
+use Peast\Syntax\Node\Expression;
 
 /**
  * A node that represents a JSX fragment.

--- a/lib/Peast/Syntax/Node/JSX/JSXOpeningElement.php
+++ b/lib/Peast/Syntax/Node/JSX/JSXOpeningElement.php
@@ -9,8 +9,8 @@
  */
 namespace Peast\Syntax\Node\JSX;
 
-use \Peast\Syntax\Node\Node;
-use \Peast \Syntax\Node\Expression;
+use Peast\Syntax\Node\Node;
+use Peast\Syntax\Node\Expression;
 
 /**
  * A node that represents a JSX opening element tag.


### PR DESCRIPTION
As of PHP 8.0, whitespace is no longer allowed within a namespaced name.

The Peast project even got a mention in the RFC in which this change was proposed as one of the very few projects which would be affected by this change.

This commit fixes the issue.

Note: as import `use` statements _always_ have to use fully qualified names, a leading backslash is unnecessary and strongly discouraged, though it won't cause a parse error (yet).

With that in mind, I've removed the leading backslashes in the files affected by the PHP 8 change as well, but haven't touched any of the other files containing import `use` statements with leading backslashes.

I'd encourage you to remove those as well though, but that is outside the scope of this PR.

Ref: https://wiki.php.net/rfc/namespaced_names_as_token