### PR TITLE
Make the test suite compatible with higher PHPUnit versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 nbproject/
 .idea/
 composer.lock
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0|^5.0"
+        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/test/Peast/PeastTest.php
+++ b/test/Peast/PeastTest.php
@@ -43,12 +43,11 @@ class PeastTest extends TestBase
     {
         $this->assertTrue(\Peast\Peast::latest("")->getFeatures() instanceof \Peast\Syntax\ES2020\Features);
     }
-    
-    /**
-     * @expectedException \Exception
-     */
+
     public function testInvalidVersion()
     {
+        $this->expectException('Exception');
+
         \Peast\Peast::ES("");
     }
 }

--- a/test/Peast/RendererTest.php
+++ b/test/Peast/RendererTest.php
@@ -42,12 +42,11 @@ class RendererTest extends TestBase
         $this->assertEquals($cmTest, $cm);
         $this->assertEquals($exTest, $ex);
     }
-    
-    /**
-     * @expectedException \Exception
-     */
+
     public function testExceptionOnMissingFormatter()
     {
+        $this->expectException('Exception');
+
         $tree = \Peast\Peast::latest("")->parse();
         $renderer = new \Peast\Renderer;
         $this->assertEquals(null, $renderer->getFormatter());

--- a/test/Peast/Syntax/Node/CommentTest.php
+++ b/test/Peast/Syntax/Node/CommentTest.php
@@ -16,12 +16,11 @@ class CommentTest extends \Peast\test\TestBase
         $this->assertEquals(0, count($node->getLeadingComments()));
         $this->assertEquals(0, count($node->getTrailingComments()));
     }
-    
-    /**
-     * @expectedException \Exception
-     */
+
     public function testInvalidRawText()
     {
+        $this->expectException('Exception');
+
         $node = new Node\Comment;
         $node->setRawText("test");
     }

--- a/test/Peast/Syntax/Node/NumericLiteralTest.php
+++ b/test/Peast/Syntax/Node/NumericLiteralTest.php
@@ -101,11 +101,11 @@ class NumericLiteralTest extends \Peast\test\TestBase
     
     /**
      * @dataProvider invalidNumbersProvider
-     * 
-     * @expectedException \Exception
      */
     public function testInvalidNumbers($num)
     {
+        $this->expectException('Exception');
+
         $node = new Node\NumericLiteral;
         $node->setRaw($num);
     }

--- a/test/Peast/Syntax/Node/StringLiteralTest.php
+++ b/test/Peast/Syntax/Node/StringLiteralTest.php
@@ -44,11 +44,11 @@ class StringLiteralTest extends \Peast\test\TestBase
     
     /**
      * @dataProvider invalidStringsProvider
-     * 
-     * @expectedException \Exception
      */
     public function testInvalidString($string)
     {
+        $this->expectException('Exception');
+
         $node = new Node\StringLiteral;
         $node->setRaw($string);
     }

--- a/test/Peast/Syntax/ScannerTest.php
+++ b/test/Peast/Syntax/ScannerTest.php
@@ -15,12 +15,11 @@ class ScannerTest extends \Peast\test\TestBase
             $this->assertEquals($UTF8Char, $str);
         }
     }
-    
-    /**
-     * @expectedException \Peast\Syntax\EncodingException
-     */
+
     public function testExceptionOnInvalidUTF8()
     {
+        $this->expectException('Peast\Syntax\EncodingException');
+
         $UTF8Char = chr(0xc2) . chr(0xb0);
         $source = "'" . $UTF8Char . $UTF8Char[0] . "'";
         \Peast\Peast::latest($source)->parse();

--- a/test/Peast/TestCaseBase.php
+++ b/test/Peast/TestCaseBase.php
@@ -2,7 +2,35 @@
 namespace Peast\test;
 
 if (class_exists("\PHPUnit\Framework\TestCase")) {
-    abstract class TestCaseBase extends \PHPUnit\Framework\TestCase{}
+    if (method_exists('\PHPUnit\Framework\TestCase', 'expectException')) {
+        abstract class TestCaseBase extends \PHPUnit\Framework\TestCase{}
+    } else {
+        abstract class TestCaseBase extends \PHPUnit\Framework\TestCase{
+            /**
+             * Polyfill the expectException method for low PHPUnit versions.
+             */
+            public function expectException($exception)
+            {
+                if (method_exists('PHPUnit_Framework_TestCase', 'expectException')) {
+                    parent::expectException($exception);
+                } else {
+                    $this->setExpectedException($exception);
+                }
+            }
+        }
+    }
 } else {
-    abstract class TestCaseBase extends \PHPUnit_Framework_TestCase{}
+    abstract class TestCaseBase extends \PHPUnit_Framework_TestCase{
+        /**
+         * Polyfill the expectException method for low PHPUnit versions.
+         */
+        public function expectException($exception)
+        {
+            if (method_exists('PHPUnit_Framework_TestCase', 'expectException')) {
+                parent::expectException($exception);
+            } else {
+                $this->setExpectedException($exception);
+            }
+        }
+    }
 }

--- a/test/Peast/TestParser.php
+++ b/test/Peast/TestParser.php
@@ -78,13 +78,14 @@ abstract class TestParser extends TestBase
     {
         return parent::getJsTestFiles(self::JS_INVALID);
     }
-    
+
     /**
-     * @expectedException \Peast\Syntax\Exception
      * @dataProvider invalidJsTestFilesProvider
      */
     public function testParserException($sourceFile)
     {
+        $this->expectException('Peast\Syntax\Exception');
+
         $this->instanceParser($sourceFile)->parse();
     }
     
@@ -161,13 +162,14 @@ abstract class TestParser extends TestBase
         }
         return $ret;
     }
-    
+
     /**
-     * @expectedException \Peast\Syntax\Exception
      * @dataProvider invalidFutureFeaturesProvider
      */
     public function testFutureFeaturesParsingFail($feature, $sourceFile)
     {
+        $this->expectException('Peast\Syntax\Exception');
+
         if ($feature === null) {
             throw new \Peast\Syntax\Exception("Nothing to test", new \Peast\Syntax\Position(0, 0, 0));
         } else {


### PR DESCRIPTION
### Tests: polyfill the PHPUnit `expectException()` method

This selectively polyfills the PHPUnit native `expectException()` method.

Context:
The `@expectedException` annotations are deprecated in PHPUnit 8 and no longer supported in PHPUnit 9.

PHPUnit 9 is needed to be able to run the tests on PHP 8 (expected end of November 2020), so making the test suite compatible with PHPUnit 9 is a good idea.

Rationale for the three different test cases:
* The `expectException()` method was introduced in PHPUnit 5.
* A forward compatibility layer for the namespaced `PHPUnit\Framework\TestCase` class is included in some of the last versions of PHPUnit 4.x and 5.x and the namespaced `TestCase` is the official and only supported `TestCase` as of PHPUnit 6.0.
* PHPUnit 8 added type declarations to various PHPUnit methods, including the `string` type declaration for the `$exception` parameter and a `void` return type declaration for this method.
* Overloading the method with the type declarations is not possible as the `void` return type wasn't introduced until PHP 7.1, so that would break the test suite on PHP < 7.1.
* As these type declarations cause an "incompatible signature" error if we'd overload the method in the `TestBase` class without the type declarations, the overload needs to be done in the `TestCaseBase` class, but only for those classes were the `expectException()` method isn't natively declared in PHPUnit to prevent the signature mismatch.

### Tests: replace exception annotations with method calls

Replace `@expectedException` annotations used in the test suite with calls to the PHPUnit/polyfilled `expectException()` method.

### Composer: allow for PHPUnit 4 - 9

With the changes made in the previous two commits, the unit tests are now compatible with PHPUnit 4.x - 9.x, so the version constraints in the `composer.json` file can be widened.

Includes adding the PHPUnit 8/9 `.phpunit.result.cache` cache file to `.gitignore`.

