### PR TITLE
Travis: update the distro + PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,34 @@
+os: linux
 language: php
 
-dist: trusty
-
 php:
-    - '5.4'
-    - '5.5'
-    - '5.6'
-    - '7.0'
-    - '7.1'
-    - '7.2'
-    - '7.3'
+    - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
+    - 7.4
+    - "nightly"
 
-install: composer install
+jobs:
+    fast_finish: true
+    include:
+        - php: 5.4
+          dist: trusty
+        - php: 5.5
+          dist: trusty
+
+    allow_failures:
+        # Allow failures for unstable builds.
+        - php: "nightly"
+
+install:
+  - |
+    if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      # Not all PHPUnit dependencies have stable releases yet allowing for PHP 8.0.
+      travis_retry composer install --no-interaction --ignore-platform-reqs
+    else
+      travis_retry composer install --no-interaction
+    fi
 
 script: ./vendor/bin/phpunit -c phpunit.xml


### PR DESCRIPTION
Now #23 and #24 have been merged, let's test against PHP8.

* The `trusty` distro is no longer supported by Travis. Removing the `dist: trusty` will let the script fall back to the default, which is currently `xenial`.
* The `xenial` distro however, does not support PHP 5.4/5.5, so adding the `jobs` key to specifically set the distro to `trusty` for those builds.
* Test against PHP 7.4, which was released nearly a year ago.
* Test against PHP `nightly` (PHP 8.0) which is expected to be released by end of November of this year.
    Until PHP 8.0 is released, the build should be allowed to fail on PHP 8.0.
    Also note: while PHPUnit 9.3.x is compatible with PHP 8, not all PHPUnit dependencies have tagged a release yet saying they are, so installation needs to use `--ignore-platform-reqs` to actually get PHPUnit 9.
* Also: remove the unnecessary quotes around the Travis version numbers.

Includes adding `travis_retry` before the `composer install` command. Build are failing regularly on a peer fingerprint mismatch on `composer install`. Using `travis_retry` means Travis will try two more times before failing the build, reducing the annoyance of having to continuously manually restart builds.

Note: it looks like Travis is no longer automatically reporting back on the builds. This is not something which can be fixed via a PR, but needs to be done by a maintainer.
See here for a thread on how to fix this: https://twitter.com/jrf_nl/status/1255854838597984262

To see that the build is actually passing for this PR: https://travis-ci.com/github/jrfnl/peast/builds/185326447