### PR TITLE
Fix incompatibility with PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"

--- a/lib/Peast/Syntax/Utils.php
+++ b/lib/Peast/Syntax/Utils.php
@@ -34,7 +34,7 @@ class Utils
         if ($str === "") {
             return array();
         }
-        $ret = preg_split('//u', $str, null, PREG_SPLIT_NO_EMPTY);
+        $ret = preg_split('//u', $str, -1, PREG_SPLIT_NO_EMPTY);
         if (preg_last_error() === PREG_BAD_UTF8_ERROR) {
             if (!$strictEncoding) {
                 $str = mb_convert_encoding($str, 'UTF-8', 'UTF-8');


### PR DESCRIPTION
Fix "deprecated" error "preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated"