### PR TITLE
Fix PHP 8.5 compatibility

### DIFF
--- a/lib/Peast/Syntax/Node/NumericLiteral.php
+++ b/lib/Peast/Syntax/Node/NumericLiteral.php
@@ -115,7 +115,7 @@ class NumericLiteral extends Literal
             //Numeric separator cannot appear at the beginning or at the end of the number
             if (preg_match("/^_|_$/", $value)) {
                 throw new \Exception("Invalid numeric value");
-            } elseif (isset($this->forms[$form])) {
+            } elseif (isset($this->forms[$form ?? ''])) {
                 $formDef = $this->forms[$form];
                 if (!preg_match($formDef["check"], $value)) {
                     throw new \Exception("Invalid " . $formDef["format"]);


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists

faced in Drupal 11 core tests

```
Asset Optimization (Drupal\FunctionalTests\Asset\AssetOptimization)
     ✘ Asset aggregation
       ┐
       ├ Exception: Deprecated function: Using null as an array offset is deprecated, use an empty string instead
       ├ Peast\Syntax\Node\NumericLiteral->setRaw()() (Line: 118)                 
       │
       │ /builds/issue/drupal-3523596/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php:55
       │ /builds/issue/drupal-3523596/vendor/guzzlehttp/promises/src/Promise.php:209
       │ /builds/issue/drupal-3523596/vendor/guzzlehttp/promises/src/Promise.php:158
       │ /builds/issue/drupal-3523596/vendor/guzzlehttp/promises/src/TaskQueue.php:52
       │ /builds/issue/drupal-3523596/vendor/guzzlehttp/promises/src/Promise.php:251
       │ /builds/issue/drupal-3523596/vendor/guzzlehttp/promises/src/Promise.php:227
       │ /builds/issue/drupal-3523596/vendor/guzzlehttp/promises/src/Promise.php:272
       │ /builds/issue/drupal-3523596/vendor/guzzlehttp/promises/src/Promise.php:229
       │ /builds/issue/drupal-3523596/vendor/guzzlehttp/promises/src/Promise.php:69
       │ /builds/issue/drupal-3523596/vendor/guzzlehttp/guzzle/src/Client.php:189
       │ /builds/issue/drupal-3523596/core/tests/Drupal/Tests/DrupalTestBrowser.php:139
       │ /builds/issue/drupal-3523596/vendor/symfony/browser-kit/AbstractBrowser.php:378
       │ /builds/issue/drupal-3523596/vendor/behat/mink-browserkit-driver/src/BrowserKitDriver.php:122
       │ /builds/issue/drupal-3523596/vendor/behat/mink/src/Session.php:175
       │ /builds/issue/drupal-3523596/core/tests/Drupal/FunctionalTests/Asset/AssetOptimizationTest.php:140
       │ /builds/issue/drupal-3523596/core/tests/Drupal/FunctionalTests/Asset/AssetOptimizationTest.php:118
       │ /builds/issue/drupal-3523596/core/tests/Drupal/FunctionalTests/Asset/AssetOptimizationTest.php:45
       ┴
```