### PR TITLE
parseArrowFunction should not throw an exception when it can't parse arrow parameters.

### DIFF
--- a/lib/Peast/Syntax/Parser.php
+++ b/lib/Peast/Syntax/Parser.php
@@ -2897,7 +2897,13 @@ class Parser extends ParserAbstract
             ($async = $this->checkAsyncFunctionStart(false))) {
             $this->scanner->consumeToken();
         }
-        if (($params = $this->parseArrowParameters()) !== null) {
+        // We might be parsing a ParenthesizedExpression, return null instead of throwing an exception if we can't parse the parameters.
+        try {
+            $params = $this->parseArrowParameters();
+        } catch (Exception $e) {
+            $params = null;
+        }
+        if ($params !== null) {
 
             if ($this->scanner->noLineTerminators() &&
                 $this->scanner->consume("=>")


### PR DESCRIPTION
To handle a `CoverParenthesizedExpressionAndArrowParameterList`, we first evaluate it as a possible `ArrowFunction` then fall back to a `ParenthesizedExpression` . 

We begin with validating the ArrowParameters and throw an Exception if the ArrowParameters are not valid.

Example code - ParenthesizedExpression:

```
var_dump( Peast\Peast::latest( '([...new Set()])' )->parse() );
```

Output on master:
```
PHP Fatal error:  Uncaught Peast\Syntax\Exception: Unexpected: new in peast-source/lib/Peast/Syntax/ParserAbstract.php:305
Stack trace:
 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(2553): Peast\Syntax\ParserAbstract->error()
#1 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(2520): Peast\Syntax\Parser->parseBindingRestElement()
#2 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(2478): Peast\Syntax\Parser->parseArrayBindingPattern()
#3 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(2567): Peast\Syntax\Parser->parseBindingPattern()
#4 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(1635): Peast\Syntax\Parser->parseBindingElement()
#5 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(2840): Peast\Syntax\Parser->parseFormalParameterList()
#6 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(2900): Peast\Syntax\Parser->parseArrowParameters()
#7 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(3171): Peast\Syntax\Parser->parseArrowFunction()
#8 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/ParserAbstract.php(349): Peast\Syntax\Parser->parseAssignmentExpression()
#9 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(3151): Peast\Syntax\ParserAbstract->charSeparatedListOf('parseAssignment...')
#10 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/ParserAbstract.php(213): Peast\Syntax\Parser->parseExpression()
#11 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(1000): Peast\Syntax\ParserAbstract->isolateContext(Array, 'parseExpression')
#12 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(413): Peast\Syntax\Parser->parseExpressionStatement()
#13 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(361): Peast\Syntax\Parser->parseStatement()
#14 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(340): Peast\Syntax\Parser->parseStatementListItem()
#15 /Users/sorin/experiments/peast-source/lib/Peast/Syntax/Parser.php(201): Peast\Syntax\Parser->parseStatementList(true)
#16 /Users/sorin/experiments/peast-source/test.php(4): Peast\Syntax\Parser->parse()
#17 {main}
  thrown in /Users/sorin/experiments/peast-source/lib/Peast/Syntax/ParserAbstract.php on line 305

```

As at this point we haven't confirmed we're parsing an ArrowFunction, we shouldn't throw an Exception if parsing the  `ArrowParameters` fails.

